### PR TITLE
Documents can now be files or links

### DIFF
--- a/backend/controllers/documents.js
+++ b/backend/controllers/documents.js
@@ -1,6 +1,8 @@
 const { Document } = require('../schemas');
 
 // Not RESTful
+
+// This endpoint is useful for sorted/filtered lists of documents
 const getDocumentList = async (req, res) => {
   const { sort, filter, skip } = req.body
   try {
@@ -10,9 +12,6 @@ const getDocumentList = async (req, res) => {
       .skip(skip)
       .limit(20)
       .lean()
-    result.forEach(item => {
-      item.document = item.document.toString();
-    })
     res.status(200).json(result)
   } catch (e) {
     console.log(e)
@@ -23,11 +22,11 @@ const getDocumentList = async (req, res) => {
 const getDocumentById = async (req, res) => {
 	let { id } = req.params
 	try {
-		let result = await Document.findById(id).lean()
-    result.document = result.document.toString()
+		let result = await Document.findById(id)
 		res.status(200).json(result)
 	} catch (e) {
 		res.status(500).send(e);
+    console.log(e)
 	}
 }
 
@@ -44,7 +43,8 @@ const createDocument = async (req, res) => {
 const updateDocument = async (req, res) => {
   let { id } = req.params
   try {
-    await Document.findByIdAndUpdate(id, req.body)
+    // Make sure the document_type is available within the request body for this to work!
+    await Document.findOneAndUpdate({_id: id, document_type: req.body.document_type }, req.body)
     res.status(204).send('Document updated')
   } catch (e) {
     res.status(500).send(e)

--- a/backend/schemas/Document.js
+++ b/backend/schemas/Document.js
@@ -1,17 +1,29 @@
 let mongoose = require('mongoose')
-let Schema = mongoose.Schema
+let { Schema } = mongoose;
+
+// Discriminators offer a way for documents to have variations but still be considered
+// the same type. Here, FileDocument and LinkDocument are still instances of Document.
+let options = { discriminatorKey: 'document_type' }
 
 let DocumentSchema = new Schema({
   title: String,
   cohort: {location: String, start: String, year: Number},
   authors: Array,
-  document: Buffer,
-  document_type: String,
-  assignment: String
-})
+  document_type: { type: String, required: true }
+}, options)
 
 DocumentSchema.pre(['save', 'findOneAndUpdate'], function (){ 
   if (this.authors && this.authors.length) this.authors.sort()
 })
 
-module.exports = mongoose.model('Document', DocumentSchema)
+const Document = mongoose.model('Document', DocumentSchema)
+
+const FileDocument = Document.discriminator('file',
+  new Schema({ file: { type: Buffer, required: true } }, options)
+)
+const LinkDocument = Document.discriminator('link',
+  new Schema({ link: { type: String, required: true } }, options)
+)
+
+
+module.exports = Document


### PR DESCRIPTION
Through the use of Mongoose discriminators, Documents can either be files or links. Documents with a file can have a `file` property, and documents with links have a `link` property. The discriminator is the `document_type` key which can be `'file'` or `'link'` and must be preset at the creation of new documents. CRUD has been tested and works, at least on the backend. 